### PR TITLE
fix: 修复ts中使用gogocode一系列的类型报错问题

### DIFF
--- a/packages/gogocode-core/types/index.d.ts
+++ b/packages/gogocode-core/types/index.d.ts
@@ -38,7 +38,7 @@ declare module 'gogocode' {
         value: string;
       }>;
     };
-    type NodeAndString = string | ASTNode;
+    type NodeAndString = string | Partial<ASTNode>;
     type Selector = NodeAndString;
     type Replacer = NodeAndString;
 
@@ -129,7 +129,7 @@ declare module 'gogocode' {
        * 修改多个属性名称对应的节点或属性值
        * @param attrMap { attrPath: attrValue }
        */
-      attr(attrMap: { [k: string]: ASTNode | string }): GoGoAST;
+      attr(attrMap: { [k: string]: NodeAndString }): GoGoAST;
       /**
        * 判断是否有某个子节点
        * @param selector 代码选择器，可以是代码也可以将代码中的部分内容挖空替换为通配符

--- a/packages/gogocode-core/types/index.d.ts
+++ b/packages/gogocode-core/types/index.d.ts
@@ -204,6 +204,6 @@ declare module 'gogocode' {
       writeFile(code: string, filename: string): void;
     }
   }
-  const $: GoGoCode.$;
-  export = $;
+  const GoGoCode: GoGoCode.$;
+  export = GoGoCode;
 }


### PR DESCRIPTION
当前的类型定义，对`TS`中使用不是很友好，此次 PR 主要解决下述出现的问题

在ts中使用`GoGoCode`时类型检测报错

使用方法如下
```ts
import $ from 'gogocode'
import type { GoGoOption } from 'gogocode'

export function AST(code: string, ops?: GoGoOption) {
  return $(code, ops)
}
```

目前会有下面的类型报错问题
## Problem1
```ts
import $ from 'gogocode'

export function AST(code: string) {
  return $(code)
}
```
ts报错信息
```ts
导出函数的返回类型具有或正在使用外部模块“"gogocode"”中的名称“GoGoCode.GoGoAST”，但不能为其命名。ts(4058)
```
![image](https://user-images.githubusercontent.com/42485491/146207217-7b8db418-2773-4f6f-8f35-27536157f59d.png)

## Problem2
当前实现无法在`ts`中使用`GoGoCode`中其它类型
```ts
import $ from 'gogocode'
import type { GoGoOption } from 'gogocode'
```
错误提示信息
```ts
模块“"gogocode"”没有导出的成员“GoGoOption”。ts(2305)
```
![image](https://user-images.githubusercontent.com/42485491/146207621-8544d469-506b-46c7-8e6e-dd76b26ad417.png)
