### PR TITLE
feat(gogocode-plugin-prettier): support to format code by config file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@ packages/transform-project
 packages/gogocode-vue-playground
 packages/gogocode-element-playground
 packages/gogocode-core/umd
+packages/gogocode-plugin-prettier/test/output

--- a/packages/gogocode-plugin-prettier/index.js
+++ b/packages/gogocode-plugin-prettier/index.js
@@ -1,4 +1,6 @@
 const prettier = require('prettier');
+const path = require("path")
+const fs = require("fs")
 
 /**
  * 转换入口导出一个函数，按照如下函数签名
@@ -24,12 +26,29 @@ module.exports = function (fileInfo, api, options) {
         return sourceCode;
     }
 
-    return prettier.format(sourceCode, {
+    let prettierConfig = {
         trailingComma: 'es5',
         tabWidth: 2,
         semi: false,
         singleQuote: true,
         printWidth: 80,
         parser: /\.vue$/.test(fileInfo.path) ? 'vue' : 'typescript',
-    });
+    };
+    const { prettierrc, rootPath } = options
+    if (prettierrc) {
+        let prettierConfigFilePath = prettier.resolveConfigFile.sync(
+            path.resolve(rootPath, prettierrc)
+        )
+        if (fs.existsSync(prettierConfigFilePath)) {
+            const resolvedConfig = prettier.resolveConfig.sync(prettierConfigFilePath)
+            prettierConfig = {
+                ...prettierConfig,
+                ...resolvedConfig
+            }
+        } else {
+            console.warn(`prettier config file ${prettierConfigFilePath} not found`)
+        }
+    }
+
+    return prettier.format(sourceCode, prettierConfig);
 };

--- a/packages/gogocode-plugin-prettier/package.json
+++ b/packages/gogocode-plugin-prettier/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.1",
   "description": "",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test:api": "node ./test/run.js",
+    "test:command": "gogocode -s test/input.js -t index.js -o test/output/cli.js --params=prettierrc=test/.prettierrc.json"
+  },
   "keywords": [
     "vue",
     "gogocode",
@@ -13,5 +16,9 @@
   "license": "ISC",
   "dependencies": {
     "prettier": "^2.2.1"
+  },
+  "devDependencies": {
+    "gogocode": "^1.0.53",
+    "gogocode-cli": "^0.2.27"
   }
 }

--- a/packages/gogocode-plugin-prettier/test/.prettierrc.json
+++ b/packages/gogocode-plugin-prettier/test/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 4,
+  "useTabs": false,
+  "singleQuote": true,
+  "semi": true,
+  "printWidth": 120
+}

--- a/packages/gogocode-plugin-prettier/test/input.js
+++ b/packages/gogocode-plugin-prettier/test/input.js
@@ -1,0 +1,21 @@
+function HelloWorld({greeting = "hello", greeted = '"World"', silent = false, onMouseOver,}) {
+
+  if(!greeting){return null};
+
+     // TODO: Don't use random in render
+  let num = Math.floor (Math.random() * 1E+7).toString().replace(/\.\d+/ig, "")
+
+  return <div className='HelloWorld' title={`You are visitor number ${ num }`} onMouseOver={onMouseOver}>
+
+    <strong>{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }</strong>
+    {greeting.endsWith(",") ? " " : <span style={{color: '\grey'}}>", "</span> }
+    <em>
+	{ greeted }
+	</em>
+    { (silent)
+      ? "."
+      : "!"}
+
+    </div>;
+
+}

--- a/packages/gogocode-plugin-prettier/test/output/cli.js
+++ b/packages/gogocode-plugin-prettier/test/output/cli.js
@@ -1,0 +1,19 @@
+function HelloWorld({ greeting = 'hello', greeted = '"World"', silent = false, onMouseOver }) {
+    if (!greeting) {
+        return null;
+    }
+
+    // TODO: Don't use random in render
+    let num = Math.floor(Math.random() * 1e7)
+        .toString()
+        .replace(/\.\d+/gi, '');
+
+    return (
+        <div className="HelloWorld" title={`You are visitor number ${num}`} onMouseOver={onMouseOver}>
+            <strong>{greeting.slice(0, 1).toUpperCase() + greeting.slice(1).toLowerCase()}</strong>
+            {greeting.endsWith(',') ? ' ' : <span style={{ color: 'grey' }}>", "</span>}
+            <em>{greeted}</em>
+            {silent ? '.' : '!'}
+        </div>
+    );
+}

--- a/packages/gogocode-plugin-prettier/test/output/custom-config.js
+++ b/packages/gogocode-plugin-prettier/test/output/custom-config.js
@@ -1,0 +1,19 @@
+function HelloWorld({ greeting = 'hello', greeted = '"World"', silent = false, onMouseOver }) {
+    if (!greeting) {
+        return null;
+    }
+
+    // TODO: Don't use random in render
+    let num = Math.floor(Math.random() * 1e7)
+        .toString()
+        .replace(/\.\d+/gi, '');
+
+    return (
+        <div className="HelloWorld" title={`You are visitor number ${num}`} onMouseOver={onMouseOver}>
+            <strong>{greeting.slice(0, 1).toUpperCase() + greeting.slice(1).toLowerCase()}</strong>
+            {greeting.endsWith(',') ? ' ' : <span style={{ color: 'grey' }}>", "</span>}
+            <em>{greeted}</em>
+            {silent ? '.' : '!'}
+        </div>
+    );
+}

--- a/packages/gogocode-plugin-prettier/test/output/no-config.js
+++ b/packages/gogocode-plugin-prettier/test/output/no-config.js
@@ -1,0 +1,34 @@
+function HelloWorld({
+  greeting = 'hello',
+  greeted = '"World"',
+  silent = false,
+  onMouseOver,
+}) {
+  if (!greeting) {
+    return null
+  }
+
+  // TODO: Don't use random in render
+  let num = Math.floor(Math.random() * 1e7)
+    .toString()
+    .replace(/\.\d+/gi, '')
+
+  return (
+    <div
+      className="HelloWorld"
+      title={`You are visitor number ${num}`}
+      onMouseOver={onMouseOver}
+    >
+      <strong>
+        {greeting.slice(0, 1).toUpperCase() + greeting.slice(1).toLowerCase()}
+      </strong>
+      {greeting.endsWith(',') ? (
+        ' '
+      ) : (
+        <span style={{ color: 'grey' }}>", "</span>
+      )}
+      <em>{greeted}</em>
+      {silent ? '.' : '!'}
+    </div>
+  )
+}

--- a/packages/gogocode-plugin-prettier/test/run.js
+++ b/packages/gogocode-plugin-prettier/test/run.js
@@ -1,0 +1,47 @@
+const $ = require('gogocode');
+const t = require('../index');
+const path = require('path');
+const fs = require('fs');
+
+const inputPath = path.resolve(__dirname, './input.js');
+const outputPath = path.resolve(__dirname, './output/no-config.js');
+const outputPathWithConfig = path.resolve(__dirname, './output/custom-config.js');
+
+fs.readFile(inputPath, function read(err, code) {
+    if (err) {
+        throw err;
+    }
+    const outputCode = t(
+        {
+            source: code.toString(),
+            path: inputPath
+        },
+        {
+            gogocode: $
+        },
+        {
+            rootPath: __dirname,
+            outFilePath: outputPath,
+            outRootPath: __dirname,
+        }
+    );
+    const outputCodeWithConfig = t(
+        {
+            source: code.toString(),
+            path: inputPath
+        },
+        {
+            gogocode: $
+        },
+        {
+            rootPath: __dirname,
+            outFilePath: outputPath,
+            outRootPath: __dirname,
+            prettierrc: "./prettierrc.json"
+        }
+    );
+
+    fs.writeFileSync(outputPath, outputCode, { encoding: "utf-8" });
+    fs.writeFileSync(outputPathWithConfig, outputCodeWithConfig, { encoding: "utf-8" });
+    console.log('The file was saved!');
+});


### PR DESCRIPTION
## 功能描述

这个PR是用于解决`gogocode-plugin-prettier`无法自定义配置项的问题。
对此提供了一个加载prettier配置文件的功能。

This PR is to solve the problem that `gogocode-plugin-prettier` cannot customize code format style.
Now provide a feature that support to load a prettier configuration file.

## API
```
gogocode -s input.js -t gogocode-plugin-prettier -o output.js -p prettierrc=.prettierrc.json
```

## Fixes
https://github.com/thx/gogocode/issues/166

