### PR TITLE
fix(vue): sfc block positions

### DIFF
--- a/packages/gogocode-core/src/vue-core/generate.js
+++ b/packages/gogocode-core/src/vue-core/generate.js
@@ -54,7 +54,9 @@ module.exports = function toString(sfcDescriptor, options = {}) {
             // discard blocks that don't exist
             .filter((block) => block != null)
             // sort blocks by source position
-            .sort((a, b) => a.start - b.start)
+            .sort((a, b) => {
+                return a.loc.start.offset - b.loc.start.offset
+            })
             // figure out exact source positions of blocks
             .map((block) => {
                 const openTag = makeOpenTag(block);
@@ -64,11 +66,11 @@ module.exports = function toString(sfcDescriptor, options = {}) {
                     openTag,
                     closeTag,
 
-                    startOfOpenTag: block.start - openTag.length,
-                    endOfOpenTag: block.start,
+                    startOfOpenTag: block.loc.start.offset - openTag.length,
+                    endOfOpenTag: block.loc.start.offset,
 
-                    startOfCloseTag: block.end,
-                    endOfCloseTag: block.end + closeTag.length
+                    startOfCloseTag: block.loc.end.offset,
+                    endOfCloseTag: block.loc.end.offset + closeTag.length
                 });
             })
             // generate sfc source
@@ -84,8 +86,6 @@ module.exports = function toString(sfcDescriptor, options = {}) {
                     newlinesBefore =
                         block.startOfOpenTag - prevBlock.endOfCloseTag;
                 }
-
-                newlinesBefore = newlinesBefore || 1
 
                 return (
                     sfcCode +

--- a/packages/gogocode-core/src/vue-core/generate.js
+++ b/packages/gogocode-core/src/vue-core/generate.js
@@ -66,7 +66,7 @@ module.exports = function toString(sfcDescriptor, options = {}) {
                     openTag,
                     closeTag,
 
-                    startOfOpenTag: block.loc.start.offset - openTag.length,
+                    startOfOpenTag: block.loc.start.offset - (block.loc.start.column === 1 ? 0 : openTag.length),
                     endOfOpenTag: block.loc.start.offset,
 
                     startOfCloseTag: block.loc.end.offset,

--- a/packages/gogocode-core/src/vue-core/generate.js
+++ b/packages/gogocode-core/src/vue-core/generate.js
@@ -70,7 +70,7 @@ module.exports = function toString(sfcDescriptor, options = {}) {
                     endOfOpenTag: block.loc.start.offset,
 
                     startOfCloseTag: block.loc.end.offset,
-                    endOfCloseTag: block.loc.end.offset + closeTag.length
+                    endOfCloseTag: block.loc.end.offset + (block.loc.start.column === 1 ? 1 : closeTag.length)
                 });
             })
             // generate sfc source

--- a/packages/gogocode-core/test/G.vue.test.js
+++ b/packages/gogocode-core/test/G.vue.test.js
@@ -635,3 +635,87 @@ test('test vue parseoptions', () => {
   const res = ast.generate()
   expect(res.match('&&')).toBeTruthy()
 })
+
+test('block sort order', () => {
+  const ast = $(`
+<template>
+  <div>Test</div>
+</template>
+
+<i18n>
+{
+  "en": {
+    "test" "Test"
+  }
+}
+</i18n>
+
+<script>
+export default {};
+</script>
+`,
+      { parseOptions: { language: 'vue' } }
+  );
+  const res = ast.generate();
+  const expected = `
+<template>
+    <div>Test</div>
+</template>
+
+<i18n>
+{
+  "en": {
+    "test" "Test"
+  }
+}
+</i18n>
+
+<script>
+export default {};
+</script>
+`;
+  expect(res).toEqual(expected);
+});
+
+
+test('block newlines', () => {
+  const ast = $(`
+<template>
+  <div>Test</div>
+</template>
+<custom>
+//
+</custom>
+
+<script>
+export default {};
+</script>
+
+
+<style lang="css">
+.class{}
+</style>
+`,
+      { parseOptions: { language: 'vue' } }
+  );
+  const res = ast.generate();
+  const expected = `
+<template>
+    <div>Test</div>
+</template>
+<custom>
+//
+</custom>
+
+<script>
+export default {};
+</script>
+
+
+<style lang="css">
+.class{}
+</style>
+`;
+  expect(res).toEqual(expected);
+})
+;

--- a/packages/gogocode-core/test/G.vue.test.js
+++ b/packages/gogocode-core/test/G.vue.test.js
@@ -695,6 +695,7 @@ export default {};
 <style lang="css">
 .class{}
 </style>
+<style lang="css" src="test.css"></style>
 `,
       { parseOptions: { language: 'vue' } }
   );
@@ -715,6 +716,7 @@ export default {};
 <style lang="css">
 .class{}
 </style>
+<style lang="css" src="test.css"></style>
 `;
   expect(res).toEqual(expected);
 })

--- a/packages/gogocode-core/test/G.vue.test.js
+++ b/packages/gogocode-core/test/G.vue.test.js
@@ -696,6 +696,7 @@ export default {};
 .class{}
 </style>
 <style lang="css" src="test.css"></style>
+<style lang="css" src="another.css"></style>
 `,
       { parseOptions: { language: 'vue' } }
   );
@@ -717,6 +718,7 @@ export default {};
 .class{}
 </style>
 <style lang="css" src="test.css"></style>
+<style lang="css" src="another.css"></style>
 `;
   expect(res).toEqual(expected);
 })


### PR DESCRIPTION
Fixes Vue SFC custom block sort ordering + newlines.

`block.start` & `block.end` were undefined so this changes to `block.loc.start.offset` & `block.loc.end.offset` as per https://github.com/vuejs/core/blob/v3.0.11/packages/compiler-core/src/ast.ts#L73-L82