### PR TITLE
fix(gogocode-element-playground, gogocode-plugin-element): @element-plus/icons to @element-plus/icons-vue

### DIFF
--- a/packages/gogocode-element-playground/packages/vue3/src/components/icon/Comp-out.vue
+++ b/packages/gogocode-element-playground/packages/vue3/src/components/icon/Comp-out.vue
@@ -21,7 +21,7 @@
 import {
   CirclePlus as ElIconCirclePlus,
   Search as ElIconSearch,
-} from '@element-plus/icons'
+} from '@element-plus/icons-vue'
 import * as Vue from 'vue'
 export default {
   data() {

--- a/packages/gogocode-element-playground/packages/vue3/src/components/icon/Comp.vue
+++ b/packages/gogocode-element-playground/packages/vue3/src/components/icon/Comp.vue
@@ -9,7 +9,7 @@
 
 <script>
 import { version } from 'vue';
-import { Search as ElIconSearch, Coffee as ElIconCoffee } from '@element-plus/icons'
+import { Search as ElIconSearch, Coffee as ElIconCoffee } from '@element-plus/icons-vue'
 
 export default {
   name: 'icon',

--- a/packages/gogocode-plugin-element/src/icon.js
+++ b/packages/gogocode-plugin-element/src/icon.js
@@ -20,7 +20,7 @@ function addIconImport(scriptAst, icons) {
         scriptAst.prepend(
             `import { ${icons
                 .map((icon) => `${capitalizeFirstLetter(icon)} as ElIcon${capitalizeFirstLetter(icon)}`)
-                .join(',')} } from '@element-plus/icons'`
+                .join(',')} } from '@element-plus/icons-vue'`
         );
     }
 


### PR DESCRIPTION
Since @element-plus/icons is deprecated, I modified it to convert to @element-plus/icons-vue.

@element-plus/icons
>This package has been deprecated
>Author message:
>
>Please use @element-plus/icons-vue instead.
https://www.npmjs.com/package/@element-plus/icons