### PR TITLE
fix: 指令生命周期中，卸载的钩子名称是"unmounted"，不是“unMounted”。

### DIFF
--- a/packages/gogocode-plugin-vue/src/custom-directives.js
+++ b/packages/gogocode-plugin-vue/src/custom-directives.js
@@ -17,7 +17,7 @@ module.exports = function (ast, api, options) {
         inserted: 'mounted',
         update: 'updated',
         componentUpdated: 'updated',
-        unbind: 'unMounted',
+        unbind: 'unmounted',
     };
 
     function processHookNodes(hookNodes) {


### PR DESCRIPTION
fix：修复，指令生命周期中，卸载的钩子名称从unMounted改为unmounted。